### PR TITLE
Qt 6.9 fix: Adjust painter scaling for horizontal and vertical lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        qtver: [5.12.12, 6.5.3]
+        qtver: [6.5.3, 6.9]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.qtver }}
           dir: "${{ github.workspace }}/Qt/"
@@ -28,13 +28,7 @@ jobs:
       - name: Use MSVC (Windows)
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Configure 5.12
-        if: "contains( matrix.qtver, '5.12')"
-        run: |
-          cmake -S . -B build
-
-      - name: Configure 6.5
-        if: "contains( matrix.qtver, '6.5')"
+      - name: Configure
         run: |
           cmake -S . -DUSE_QT6=TRUE -B build
   

--- a/src/qwt_graphic.cpp
+++ b/src/qwt_graphic.cpp
@@ -118,18 +118,33 @@ static inline void qwtExecCommand(
             {
                 const QTransform tr = painter->transform();
 
-                painter->resetTransform();
+                // Qt 6.9 fix: Check for degenerate transform (zero scale factors)
+                // which would collapse the path to nothing when mapped
+                const bool hasValidScale = ( qAbs( tr.m11() ) > 1e-10 || qAbs( tr.m12() ) > 1e-10 ) &&
+                                           ( qAbs( tr.m21() ) > 1e-10 || qAbs( tr.m22() ) > 1e-10 );
 
-                QPainterPath path = tr.map( *cmd.path() );
-                if ( initialTransform )
+                if ( hasValidScale )
                 {
-                    painter->setTransform( *initialTransform );
-                    path = initialTransform->inverted().map( path );
+                    painter->resetTransform();
+
+                    QPainterPath path = tr.map( *cmd.path() );
+                    if ( initialTransform )
+                    {
+                        painter->setTransform( *initialTransform );
+                        path = initialTransform->inverted().map( path );
+                    }
+
+                    painter->drawPath( path );
+
+                    painter->setTransform( tr );
                 }
-
-                painter->drawPath( path );
-
-                painter->setTransform( tr );
+                else
+                {
+                    // Degenerate transform - use the render transform instead
+                    painter->setTransform( transform );
+                    painter->drawPath( *cmd.path() );
+                    painter->setTransform( tr );
+                }
             }
             else
             {
@@ -262,7 +277,7 @@ class QwtGraphic::PathInfo
         const QRectF& targetRect, bool scalePens ) const
     {
         if ( pathRect.width() <= 0.0 )
-            return 0.0;
+            return 1.0;  // Return 1.0 for zero-width paths (vertical lines)
 
         const QPointF p0 = m_pointRect.center();
 
@@ -293,7 +308,7 @@ class QwtGraphic::PathInfo
         const QRectF& targetRect, bool scalePens ) const
     {
         if ( pathRect.height() <= 0.0 )
-            return 0.0;
+            return 1.0;  // Return 1.0 for zero-height paths (horizontal lines)
 
         const QPointF p0 = m_pointRect.center();
 


### PR DESCRIPTION
Qt 6.9 fix: Check for degenerate transform (zero scale factors) which would collapse the path to nothing when mapped
